### PR TITLE
Some users are complaining that they cannot create a new receiving address

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -794,16 +794,23 @@ WalletModel::UnlockContext WalletModel::requestUnlock()
 		|| wasEncryptionStatus == UnlockedForStakingOnly
 		|| wasEncryptionStatus == UnlockedForAnonymizationOnly;
 
+	bool valid = false;
+
 	// if the wallet is already unlocked, we do not show UI and just 
 	// continue.
 	if (requestingUnlockRequired)
 	{
         // Request UI to unlock wallet
         emit requireUnlock();
-	}
 
-    // If wallet was not unlocked, unlock was failed or cancelled, mark context as invalid
-    bool valid = getEncryptionStatus() == Unlocked;
+    	// If wallet was not unlocked, unlock was failed or cancelled, mark context as invalid
+    	valid = getEncryptionStatus() == Unlocked;
+	}
+	else
+	{
+	    // If wallet is unencrypted or unlocked.
+    	valid = wasEncryptionStatus == Unencrypted || wasEncryptionStatus == Unlocked;
+	}
 
     return UnlockContext(this, valid, 
 		// We want to restore initial state if we requested unlock from user.


### PR DESCRIPTION
Some users are complaining that they cannot create a new receiving addresses in the latest wallet (where we also merged some of your guys pull requests) because wallet complains that it isn't unlocked. - Fixed.

It only seems to happen if the user didn't encrypt the wallet.

To reproduce:
Start a new wallet
Don't encrypt it
Try to create a new receiving address