### PR TITLE
Windows Crosscompiling pathing fixes

### DIFF
--- a/compile-win-qt.sh
+++ b/compile-win-qt.sh
@@ -10,8 +10,8 @@ cd ../..
 
 cd ./src/secp256k1
 sudo ./autogen.sh
-sudo ./configure --host=i686-w64-mingw32.static --with-bignum=no --enable-module-recovery
-TARGET_OS=NATIVE_WINDOWS make CC=i686-w64-mingw32.static-g++ CXX=i686-w64-mingw32.static-g++ libsecp256k1.la libsecp256k1.so
+sudo ./configure --host=i686-w64-mingw32.static --with-bignum=no --enable-module-recovery --enable-static --disable-shared
+TARGET_OS=NATIVE_WINDOWS make CC=i686-w64-mingw32.static-g++ CXX=i686-w64-mingw32.static-g++ libsecp256k1.la
 sudo make install
 cd ../..
 
@@ -26,6 +26,9 @@ $MXE_PATH/usr/bin/i686-w64-mingw32.static-qmake-qt5 \
 	BDB_LIB_PATH=$MXE_LIB_PATH \
 	MINIUPNPC_INCLUDE_PATH=$MXE_INCLUDE_PATH \
 	MINIUPNPC_LIB_PATH=$MXE_LIB_PATH \
+	SECP256K1_INCLUDE_PATH=$HOME/stipend/src/secp256k1/include \
+	SECP256K1_LIB_PATH=$HOME/stipend/src/secp256k1/.libs \
+
 	QMAKE_LRELEASE=$MXE_PATH/usr/i686-w64-mingw32.static/qt5/bin/lrelease stipend.pro
 
 make -f Makefile.Release

--- a/src/qt/res/bitcoin-qt.rc
+++ b/src/qt/res/bitcoin-qt.rc
@@ -1,7 +1,7 @@
 IDI_ICON1 ICON DISCARDABLE "icons/stipend.ico"
 
 #include <windows.h>             // needed for VERSIONINFO
-#include "../../clientversion.h" // holds the needed client version information
+#include "../../misc/clientversion.h" // holds the needed client version information
 
 #define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_REVISION,CLIENT_VERSION_BUILD
 #define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_REVISION) "." STRINGIZE(CLIENT_VERSION_BUILD)


### PR DESCRIPTION
Several small fixes to make life easier for the average developer/user wishing to crosscompile from GNU/Linux to Windows, this includes:

forcing secp256k1 to build static, clientversion pathing issues (due to the fact Stipend devs organized all their files neatly and forgot to do this) 
and most importantly adding LIBSECP256K1 include/dir pathing above the qmake invocation.